### PR TITLE
Recursively merge each level of state tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "immutable": "^3.7.6",
     "lodash.isarray": "^4.0.0",
     "lodash.isfunction": "^3.0.8",
-    "lodash.isobject": "^3.0.2",
-    "lodash.merge": "^4.3.1"
+    "lodash.isobject": "^3.0.2"
   }
 }

--- a/src/__tests__/index-test.js
+++ b/src/__tests__/index-test.js
@@ -83,5 +83,21 @@ describe('merger', () => {
             merger(oldState, newState)
                 .should.deep.equal({ x: 1337, y: 1338 });
         });
+
+        it('should recursively merge deeply nested immutables', () => {
+            const oldState = { nested: { deep: map({ x: 42 }) } };
+            const newState = { nested: { deep: { x: 1337 } } };
+
+            merger(oldState, newState)
+                .should.deep.equal({ nested: { deep: map({ x: 1337 }) } });
+        });
+
+        it('should merge correctly new immutable key', () => {
+            const oldState = { };
+            const newState = { nested: { deep: map({ x: 1337 }) } };
+
+            merger(oldState, newState)
+                .should.deep.equal({ nested: { deep: map({ x: 1337 }) } });
+        });
     });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import isFunction from 'lodash.isfunction';
 import isObject from 'lodash.isobject';
 import { fromJS } from 'immutable';
 
-function immutableMerger(oldState, newState) {
+export default function immutableMerger(oldState, newState) {
     // Whole state is ImmutableJS? Easiest way to merge
     if (isFunction(oldState.mergeDeep)) {
         return oldState.mergeDeep(newState);
@@ -46,5 +46,3 @@ function immutableMerger(oldState, newState) {
 
     return result;
 }
-
-export default (oldState, newState) => immutableMerger(oldState, newState);

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,9 @@
 import isArray from 'lodash.isarray';
 import isFunction from 'lodash.isfunction';
 import isObject from 'lodash.isobject';
-import merge from 'lodash.merge';
 import { fromJS } from 'immutable';
 
-export default (oldState, newState) => {
+function immutableMerger(oldState, newState) {
     // Whole state is ImmutableJS? Easiest way to merge
     if (isFunction(oldState.mergeDeep)) {
         return oldState.mergeDeep(newState);
@@ -16,8 +15,7 @@ export default (oldState, newState) => {
     }
 
     // Otherwise we need to carefully merge to avoid deprecated warnings from
-    // ImmutableJS see #8. We inspect only the first object level, as this is
-    // a common pattern with redux!
+    // ImmutableJS see #8.
     const result = { ...oldState };
     for (const key in newState) {
         if (!newState.hasOwnProperty(key)) {
@@ -28,7 +26,7 @@ export default (oldState, newState) => {
         // Assign if we don't need to merge at all
         if (!result.hasOwnProperty(key)) {
             result[key] = isObject(value) && !isArray(value)
-                ? merge({}, value)
+                ? immutableMerger({}, value)
                 : value;
             continue;
         }
@@ -40,11 +38,13 @@ export default (oldState, newState) => {
         } else if (!!value && isFunction(value.mergeDeep)) {
             result[key] = fromJS(oldValue).mergeDeep(value);
         } else if (isObject(value) && !isArray(value)) {
-            result[key] = merge({}, oldValue, value);
+            result[key] = immutableMerger(oldValue, value);
         } else {
             result[key] = value;
         }
     }
 
     return result;
-};
+}
+
+export default (oldState, newState) => immutableMerger(oldState, newState);


### PR DESCRIPTION
As discussed in [redux-storage-decorator-immutablejs PR #5](https://github.com/michaelcontento/redux-storage-decorator-immutablejs/pull/5) this changes the merger behaviour to be recursive, so we don't get warnings when the ImmutableJS objects are on the second or deeper level of the state tree.
