### PR TITLE
Allow root keys to be null.

### DIFF
--- a/src/__tests__/index-test.js
+++ b/src/__tests__/index-test.js
@@ -43,6 +43,15 @@ describe('merger', () => {
             .should.deep.equal(map({ x: 0, y: 42 }));
     });
 
+    it('should properly merge if old state is null or undefined at the root', () => {
+        const newState = { x: 1337, y: 1338 };
+
+        merger(null, newState)
+            .should.deep.equal({ x: 1337, y: 1338 });
+        merger(void(0), newState)
+            .should.deep.equal({ x: 1337, y: 1338 });
+    });
+
     describe('issue #8 - ImmutableJS deprecated warnings', () => {
         it('should properly merge nested immutables', () => {
             const oldState = { nested: map({ x: 42 }) };

--- a/src/__tests__/index-test.js
+++ b/src/__tests__/index-test.js
@@ -87,10 +87,10 @@ describe('merger', () => {
 
         it('should properly merge if old state values with null or undefined', () => {
             const oldState = { x: null, y: void(0) };
-            const newState = { x: 1337, y: 1338 };
+            const newState = map({ x: 1337, y: 1338 });
 
             merger(oldState, newState)
-                .should.deep.equal({ x: 1337, y: 1338 });
+                .should.deep.equal(map({ x: 1337, y: 1338 }));
         });
     });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,11 @@ export default (oldState, newState) => {
         if (!!oldValue && isFunction(oldValue.mergeDeep)) {
             result[key] = oldValue.mergeDeep(value);
         } else if (!!value && isFunction(value.mergeDeep)) {
-            result[key] = fromJS(oldValue).mergeDeep(value);
+            if (!oldValue) {
+                result[key] = value;
+            } else {
+                result[key] = fromJS(oldValue).mergeDeep(value);
+            }
         } else if (isObject(value) && !isArray(value)) {
             result[key] = merge({}, oldValue, value);
         } else {

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,11 @@ import merge from 'lodash.merge';
 import { fromJS } from 'immutable';
 
 export default (oldState, newState) => {
+    // Old state is null/undefined? Just assign
+    if (oldState === null || oldState === undefined) {
+        return newState;
+    }
+
     // Whole state is ImmutableJS? Easiest way to merge
     if (isFunction(oldState.mergeDeep)) {
         return oldState.mergeDeep(newState);


### PR DESCRIPTION
I'd like to differentiate between the initial state and "content was loaded".
